### PR TITLE
Adding dependency and wiring install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ greenpithumb_git_version: "master"
 
 The source git version/branch to install GreenPiThumb.
 
+```yaml
+greenpithumb_git_repo: "https://github.com/JeetShetty/GreenPiThumb"
+```
+
+The git repository to use for GreenPiThumb.
+
 ## Dependencies
 
 None

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,5 @@
 greenpithumb_user: greenpithumb
 greenpithumb_group: greenpithumb
 greenpithumb_backend_path: "/opt/greenpithumb"
+greenpithumb_git_repo: "https://github.com/JeetShetty/GreenPiThumb"
 greenpithumb_git_version: "master"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,9 @@
   notify:
     - install Adafruit DHT library
 
+# The Adafruit DHT library will refuse to install on non SBC machines, so if
+# the target machine is not ARM-based, assume this is an install on a test
+# machine and add the force test parameter.
 - name: set Adafruit DHT library test compatibility
   set_fact:
     adafruit_dht_extra_args: "--force-test"
@@ -46,7 +49,7 @@
 
 - name: download greenpithumb backend code
   git:
-    repo: https://github.com/JeetShetty/GreenPiThumb
+    repo: "{{ greenpithumb_git_repo }}"
     dest: "{{ greenpithumb_backend_path }}"
     version: "{{ greenpithumb_git_version }}"
 
@@ -57,3 +60,16 @@
     group: "{{ greenpithumb_group }}"
     recurse: yes
     state: directory
+
+- name: install greenpithumb dependencies
+  pip:
+    requirements: "{{ greenpithumb_backend_path }}/requirements.txt"
+
+- name: create wiring config
+  copy:
+    src: "{{ greenpithumb_backend_path }}/greenpithumb/wiring_config.ini.example"
+    dest: "{{ greenpithumb_backend_path }}/greenpithumb/wiring_config.ini"
+    owner: "{{ greenpithumb_user }}"
+    group: "{{ greenpithumb_group }}"
+    mode: 0444
+    remote_src: yes


### PR DESCRIPTION
Adding a step for installing pip requirements
Adding a step for copying the wiring config file
Making the GreenPiThumb git repo configurable
Adding a comment explaining why we force test on non-ARM machines.