### PR TITLE
Simplifying the build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 *.retry
+tests/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,7 @@ services:
 
 install:
   - pip install ansible==2.2.0
-
-  # Check ansible version
-  - ansible --version
-
+  - pip install ansible-lint==3.4.10
 script:
   - ./build
 

--- a/build
+++ b/build
@@ -3,14 +3,12 @@
 # Exit immediately on error
 set -e
 
-# Pull container.
-sudo docker pull geerlingguy/docker-${distro}-ansible:latest
+echo "FROM geerlingguy/docker-${distro}-ansible:latest" > tests/Dockerfile
 
-# Customize container
+# Build container
 container_tag=${distro}:ansible
 sudo docker build \
   --rm=true \
-  --file=tests/Dockerfile.${distro} \
   --tag=${container_tag} tests
 
 # Run container in detached state
@@ -34,11 +32,8 @@ sudo docker exec "${container_id}" \
   ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml \
     --syntax-check
 
-# Ansible lint check.
-sudo docker exec "${container_id}" \
-  env TERM=xterm \
-  ansible-lint /etc/ansible/roles/role_under_test/tests/test.yml \
-    --exclude /etc/ansible/roles/geerlingguy.nginx
+# Run ansible-lint (outside of docker container).
+ansible-lint tests/test.yml
 
 # Check that role installs successfully.
 sudo docker exec "${container_id}" \
@@ -48,3 +43,4 @@ sudo docker exec "${container_id}" \
 # Clean up
 sudo docker stop "${container_id}"
 sudo docker rm "${container_id}"
+rm tests/Dockerfile

--- a/tests/Dockerfile.debian8
+++ b/tests/Dockerfile.debian8
@@ -1,7 +1,0 @@
-FROM geerlingguy/docker-debian8-ansible:latest
-
-# Install ansible-lint
-RUN apt-get update
-RUN apt-get install -y python-pip
-RUN pip install setuptools --upgrade
-RUN pip install ansible-lint

--- a/tests/Dockerfile.ubuntu1404
+++ b/tests/Dockerfile.ubuntu1404
@@ -1,6 +1,0 @@
-FROM geerlingguy/docker-ubuntu1404-ansible:latest
-
-# Install ansible-lint
-RUN apt-get update
-RUN apt-get install -y python-pip
-RUN pip install ansible-lint

--- a/tests/Dockerfile.ubuntu1604
+++ b/tests/Dockerfile.ubuntu1604
@@ -1,6 +1,0 @@
-FROM geerlingguy/docker-ubuntu1604-ansible:latest
-
-# Install ansible-lint
-RUN apt-get update
-RUN apt-get install -y python-pip
-RUN pip install ansible-lint


### PR DESCRIPTION
Changing the build to assume ansible-lint is installed on the host. Also gets
rid of the Dockerfiles and just generates them dynamically since they're now
just one-liners.