### PR TITLE
Removing Ansible from the host install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ services:
   - docker
 
 install:
-  - pip install ansible==2.2.0
   - pip install ansible-lint==3.4.10
 script:
   - ./build


### PR DESCRIPTION
We actually don't need it because we're using the Ansible version within the
Docker containers.