### PR TITLE
Adding group permissions to static web files

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -44,6 +44,7 @@
   file:
     path: "{{ greenpithumb_frontend_static_root }}"
     owner: "{{ nginx_user }}"
+    group: "{{ nginx_user }}"
     recurse: yes
     state: directory
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -173,6 +173,7 @@
     path: "/var/www/{{ item }}"
     state: directory
     owner: "{{ nginx_user }}"
+    group: "{{ nginx_user }}"
   with_items:
     - .cache
     - .config
@@ -184,6 +185,7 @@
     src: "{{ greenpithumb_images_path }}"
     dest: "{{ greenpithumb_frontend_static_root }}/app/images"
     owner: "{{ nginx_user }}"
+    group: "{{ nginx_user }}"
     state: link
 
 - name: copy greenpithumb backend systemd service file


### PR DESCRIPTION
There's no nginx_group defined by the role, so we use the nginx_user as the
group because otherwise the group defaults to root.