### PR TITLE
Removing Ubuntu build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 ---
 sudo: required
 env:
-  - distro: ubuntu1604
-    init: /lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distro: debian8
     init: /bin/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"


### PR DESCRIPTION
It seems to fail with Ansible 2.3.0 in the node_js role. We don't really need
this config, so removing it.