### PR TITLE
Switching tests to use Ansible docker connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.swp
 *.swo
 *.retry
+tests/hosts
 tests/Dockerfile
+tests/roles

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   - distro: debian8
     init: /bin/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    ANSIBLE_ROLES_PATH: ~/roles
 
 services:
   - docker
@@ -11,6 +12,8 @@ services:
 install:
   - pip install ansible==2.3.0
   - pip install ansible-lint==3.4.10
+  - mkdir "${ANSIBLE_ROLES_PATH}"
+  - printf "[defaults]\nansible_roles=${ANSIBLE_ROLES_PATH}" > ~/.ansible.cfg
 script:
   - ./build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ services:
 
 install:
   - pip install ansible==2.3.0
+  # Use a non-sudo writable location for Ansible roles.
+  - echo "ansible_roles=~/.ansible/roles" > ~/.ansible.cfg
   - pip install ansible-lint==3.4.10
 script:
   - ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 install:
   - pip install ansible==2.3.0
   # Use a non-sudo writable location for Ansible roles.
-  - echo "ansible_roles=~/.ansible/roles" > ~/.ansible.cfg
+  - printf "[defaults]\nansible_roles=~/.ansible/roles" > ~/.ansible.cfg
   - pip install ansible-lint==3.4.10
 script:
   - ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - pip install ansible==2.3.0
   - pip install ansible-lint==3.4.10
   - mkdir "${ANSIBLE_ROLES_PATH}"
-  - printf "[defaults]\nansible_roles=${ANSIBLE_ROLES_PATH}" > ~/.ansible.cfg
+  - printf "[defaults]\nhostfile=hosts\nansible_roles=${ANSIBLE_ROLES_PATH}" > ~/.ansible.cfg
 script:
   - ./build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
   - docker
 
 install:
+  - pip install ansible==2.3.0
   - pip install ansible-lint==3.4.10
 script:
   - ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ services:
 
 install:
   - pip install ansible==2.3.0
-  # Use a non-sudo writable location for Ansible roles.
-  - printf "[defaults]\nansible_roles=~/.ansible/roles" > ~/.ansible.cfg
   - pip install ansible-lint==3.4.10
 script:
   - ./build

--- a/build
+++ b/build
@@ -28,7 +28,7 @@ printf "${container_id} ansible_connection=docker\n" > hosts
 # Print ansible version.
 ansible --version
 
-sudo ansible-galaxy install -r requirements.yml
+ansible-galaxy install -r requirements.yml
 
 # Create a symlink to the role under test (removing previous if it existed)
 mkdir -p roles

--- a/build
+++ b/build
@@ -28,7 +28,7 @@ printf "${container_id} ansible_connection=docker\n" > hosts
 # Print ansible version.
 ansible --version
 
-sudo -E ansible-galaxy install -r requirements.yml
+ansible-galaxy install -r requirements.yml
 
 # Create a symlink to the role under test (removing previous if it existed)
 mkdir -p roles

--- a/build
+++ b/build
@@ -3,7 +3,7 @@
 # Exit immediately on error
 set -e
 
-pushd tests/
+cd tests/
 
 cp "Dockerfile-${distro}" Dockerfile
 
@@ -92,4 +92,3 @@ sudo docker rm "${container_id}"
 rm -rf roles
 rm Dockerfile
 rm hosts
-popd

--- a/build
+++ b/build
@@ -36,14 +36,14 @@ rm roles/role_under_test || true
 ln -s ../../ roles/role_under_test
 
 # Ansible syntax check.
-sudo ansible-playbook test.yml --syntax-check
+ansible-playbook test.yml --syntax-check
 
 # Check that role installs successfully.
-sudo ansible-playbook test.yml
+ansible-playbook test.yml
 
 # Test role idempotence.
 idempotence_file=$(mktemp)
-sudo ansible-playbook test.yml \
+ansible-playbook test.yml \
   | tee "${idempotence_file}"
 grep -q "changed=0.*failed=0" "${idempotence_file}" && \
   (echo "Idempotence test: pass" && exit 0) || \

--- a/build
+++ b/build
@@ -28,7 +28,7 @@ printf "${container_id} ansible_connection=docker\n" > hosts
 # Print ansible version.
 ansible --version
 
-ansible-galaxy install -r requirements.yml
+sudo -E ansible-galaxy install -r requirements.yml
 
 # Create a symlink to the role under test (removing previous if it existed)
 mkdir -p roles

--- a/build
+++ b/build
@@ -3,13 +3,15 @@
 # Exit immediately on error
 set -e
 
-echo "FROM geerlingguy/docker-${distro}-ansible:latest" > tests/Dockerfile
+pushd tests/
+
+cp "Dockerfile-${distro}" Dockerfile
 
 # Build container
-container_tag=${distro}:ansible
+container_tag=${distro}
 sudo docker build \
   --rm=true \
-  --tag=${container_tag} tests
+  --tag=${container_tag} .
 
 # Run container in detached state
 id_file=$(mktemp)
@@ -21,33 +23,27 @@ sudo docker run \
 container_id="$(cat $id_file)"
 echo "Container ID:" "${container_id}"
 
-# Print ansible version.
-sudo docker exec "${container_id}" \
-  env TERM=xterm \
-  ansible --version
+printf "${container_id} ansible_connection=docker\n" > hosts
 
-# Install dependencies.
-sudo docker exec "${container_id}" \
-  env TERM=xterm \
-  ansible-galaxy install \
-    -r /etc/ansible/roles/role_under_test/tests/requirements.yml
+# Print ansible version.
+ansible --version
+
+sudo ansible-galaxy install -r requirements.yml
+
+# Create a symlink to the role under test (removing previous if it existed)
+mkdir -p roles
+rm roles/role_under_test || true
+ln -s ../../ roles/role_under_test
 
 # Ansible syntax check.
-sudo docker exec "${container_id}" \
-  env TERM=xterm \
-  ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml \
-    --syntax-check
+sudo ansible-playbook test.yml --syntax-check
 
 # Check that role installs successfully.
-sudo docker exec "${container_id}" \
-  env TERM=xterm \
-  ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml
+sudo ansible-playbook test.yml
 
 # Test role idempotence.
 idempotence_file=$(mktemp)
-sudo docker exec "${container_id}" \
-  env TERM=xterm \
-  ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml \
+sudo ansible-playbook test.yml \
   | tee "${idempotence_file}"
 grep -q "changed=0.*failed=0" "${idempotence_file}" && \
   (echo "Idempotence test: pass" && exit 0) || \
@@ -87,10 +83,13 @@ else
   echo "404 test: fail" && exit 1
 fi
 
+# Check role for linter errors.
+ansible-lint test.yml -t greenpithumb
+
 # Clean up
 sudo docker stop "${container_id}"
 sudo docker rm "${container_id}"
-rm tests/Dockerfile
-
-# Check role for linter errors.
-ansible-lint tests/test.yml
+rm -rf roles
+rm Dockerfile
+rm hosts
+popd

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -46,4 +46,5 @@
   npm:
     path: "{{ greenpithumb_frontend_static_root }}"
     production: "{{ greenpithumb_npm_production_mode }}"
+  become: True
   become_user: "{{ nginx_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,10 @@
   apt:
     update_cache: true
   when: "add_adafruit_repo.changed or add_adafruit_key.changed"
+  tags:
+    # We need to run this now, so it can't be a handler
+    # [ANSIBLE0016] Tasks that run when changed should likely be handlers
+    - skip_ansible_lint
 
 - name: install Adafruit node.js package
   apt:

--- a/tests/Dockerfile-debian8
+++ b/tests/Dockerfile-debian8
@@ -1,0 +1,11 @@
+FROM debian:jessie-slim
+
+ENV TERM=xterm
+
+# Install dependencies.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       sudo python-dev python-pip\
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: localhost
+- hosts: all
   remote_user: root
   roles:
-    - role_under_test
+    - { role: role_under_test, tags: [ 'greenpithumb'] }


### PR DESCRIPTION
We were previously using Docker images that had Ansible installed and then
running Ansible within the test container. Instead, we're taking advantage of
the ansible_connection=docker option to run Ansible from the host and test
within the containers instead of installing Ansible within the containers.